### PR TITLE
Add timeOut on the message options

### DIFF
--- a/lib/ToastrBox.js
+++ b/lib/ToastrBox.js
@@ -158,12 +158,14 @@ var ToastrBox = function (_Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       var toastr = this.props.toastr;
+      var timeOut = toastr.options.timeOut;
 
-      var timeOut = _config2.default.get('timeOut');
-      var time = toastr.options.timeOut || timeOut;
+      if (typeof timeOut === 'undefined' && toastr.type !== 'message') {
+        timeOut = _config2.default.get('timeOut');
+      }
 
-      if (toastr.type !== 'message') {
-        this._setIntervalId(setTimeout(this._removeToastr, time));
+      if (timeOut) {
+        this._setIntervalId(setTimeout(this._removeToastr, timeOut));
       }
 
       this._setTransition();

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -31,11 +31,13 @@ export default class ToastrBox extends Component {
 
   componentDidMount() {
     const {toastr} = this.props;
-    const timeOut = config.get('timeOut');
-    const time = toastr.options.timeOut || timeOut;
+    let {timeOut} = toastr.options;
+    if (typeof timeOut === 'undefined' && toastr.type !== 'message') {
+      timeOut = config.get('timeOut');
+    }
 
-    if (toastr.type !== 'message') {
-      this._setIntervalId(setTimeout(this._removeToastr, time));
+    if (timeOut) {
+      this._setIntervalId(setTimeout(this._removeToastr, timeOut));
     }
 
     this._setTransition();

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,7 @@ export function mapToToastrMessage(type, array) {
   if (options) {
     obj.options = options;
   }
-  
+
   if (!obj.options.icon) {
     obj.options.icon = mapToIcon(type);
   }


### PR DESCRIPTION
#7

How about this?
It does not change the default behavior.
But if you set `timeOut` option, `message` will be disappeared after a specific number of seconds.
Besides you can stop any kind of toastr from disappearing to set timeOut to 0.
