### PR TITLE
Pass component option as JSX, rather than class reference. (Issue #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ constructor(props) {
 # Toastr methods
 ##### Toastr: `success` `info` `warning` and `error`
 Each of these methods can take up to three arguments the `title` a `message` and `options`.
-In `options` you can specify the `timeout` `icon` `onShowComplete` and `onHideComplete`.
+In `options` you can specify the `timeout` `icon` `onShowComplete` `onHideComplete` and `component`.
 
 `icon` can be one of the following:
 - `'icon-close-round'`
@@ -116,7 +116,11 @@ const toastrOptions = {
   icon: 'my-icon-name',
   onShowComplete: () => console.log('SHOW: animation is done'),
   onHideComplete: () => console.log('HIDE: animation is done'),
-  component: React.Component
+  component: (
+    <MyCustomComponent myProp="myValue">
+      <span>Hello, World!</span>
+    </MyCustomComponent>
+  )
 }
 
 toastr.success('Title', 'Message', toastrOptions)

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -1,5 +1,5 @@
 import CSSCore from 'fbjs/lib/CSSCore';
-import React, {Component, PropTypes} from 'react'; //  eslint-disable-line no-unused-vars
+import React, {Component, PropTypes, isValidElement} from 'react'; //  eslint-disable-line no-unused-vars
 import cn from 'classnames';
 
 import {onCSSTransitionEnd} from './utils';
@@ -110,14 +110,13 @@ export default class ToastrBox extends Component {
   };
 
   _renderSubComponent = (SubComponent) => {
-    // If component is a class reference, create a React element from it
-    if (SubComponent.prototype && SubComponent.prototype.render) {
-      return (
-        <SubComponent />
-      );
-    }
+    // If SubComponent is already a valid React element, just render it.
+    if (isValidElement(SubComponent)) return SubComponent;
 
-    return SubComponent;
+    // If SubComponent is a class reference, create a React element from it
+    return (
+      <SubComponent />
+    );
   };
 
   render() {

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -1,5 +1,5 @@
 import CSSCore from 'fbjs/lib/CSSCore';
-import React, {Component, PropTypes, dangerouslySetInnerHTML} from 'react'; //  eslint-disable-line no-unused-vars
+import React, {Component, PropTypes} from 'react'; //  eslint-disable-line no-unused-vars
 import cn from 'classnames';
 
 import {onCSSTransitionEnd} from './utils';
@@ -33,7 +33,7 @@ export default class ToastrBox extends Component {
     }
 
     this._setTransition();
-    onCSSTransitionEnd(this.toastrBox, this._onAnimationComplite);
+    onCSSTransitionEnd(this.toastrBox, this._onAnimationComplete);
   }
 
   componentWillUnmount() {
@@ -58,7 +58,7 @@ export default class ToastrBox extends Component {
     }
   }
 
-  _onAnimationComplite = () => {
+  _onAnimationComplete = () => {
     const {remove, item} = this.props;
     const {options, id} = item;
 
@@ -77,7 +77,7 @@ export default class ToastrBox extends Component {
     if (!this.isHiding) {
       this._setIsHiding(true);
       this._setTransition(true);
-      onCSSTransitionEnd(this.toastrBox, this._onAnimationComplite);
+      onCSSTransitionEnd(this.toastrBox, this._onAnimationComplete);
     }
   };
 
@@ -109,6 +109,17 @@ export default class ToastrBox extends Component {
     this.isHiding = val;
   };
 
+  _renderSubComponent = (SubComponent) => {
+    // If component is a class reference, create a React element from it
+    if (SubComponent.prototype && SubComponent.prototype.render) {
+      return (
+        <SubComponent />
+      );
+    }
+
+    return SubComponent;
+  };
+
   render() {
     return (
       <div
@@ -122,7 +133,7 @@ export default class ToastrBox extends Component {
           {this.props.item.message && <div className="message">{this.props.item.message}</div>}
           {this.props.item.options.component &&
             <div className="message">
-              <this.props.item.options.component />
+              {this._renderSubComponent(this.props.item.options.component)}
             </div>
           }
         </div>


### PR DESCRIPTION
Allow passing of JSX to `component` option.

Tests to see if `component` option is a class reference, so not to break existing functionality.
