### PR TITLE
confirm configuration made like toastr configuration

### DIFF
--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -25,17 +25,14 @@ export default class ReduxToastr extends Component {
   static defaultProps = {
     position: 'top-right',
     newestOnTop: true,
-    timeOut: 5000,
-    confirmOptions: {
-      okText: 'ok',
-      cancelText: 'cancel'
-    }
+    timeOut: 5000
   };
 
   constructor(props) {
     super(props);
-    config.timeOut = this.props.timeOut;
-    config.newestOnTop = this.props.newestOnTop;
+    config.toastr.timeOut = this.props.timeOut;
+    config.toastr.newestOnTop = this.props.newestOnTop;
+    config.confirm = {...config.confirm, ...this.props.confirmOptions};
   }
 
   componentDidMount() {
@@ -55,7 +52,7 @@ export default class ReduxToastr extends Component {
     return (
       <div className={cn('redux-toastr', this.props.position)}>
         {this.props.toastr &&
-            <ToastrConfirm confirm={this.props.toastr.confirm} {...this.props}/>
+            <ToastrConfirm key={this.props.toastr.confirm.id} confirm={this.props.toastr.confirm} {...this.props}/>
         }
         {this.props.toastr &&
             this.props.toastr.toastrs.map(item => <ToastrBox key={item.id} item={item}  {...this.props}/>)

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -17,8 +17,8 @@ export default class ToastrBox extends Component {
     let {options} = props.item;
     this.isHiding = false;
     this.intervalId = null;
-    this.transitionIn = options.transitionIn || config.transitionIn;
-    this.transitionOut = options.transitionOut || config.transitionOut;
+    this.transitionIn = options.transitionIn || config.toastr.transitionIn;
+    this.transitionOut = options.transitionOut || config.toastr.transitionOut;
   }
 
   componentDidMount() {

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -5,20 +5,26 @@ import cn from 'classnames';
 import CSSCore from 'fbjs/lib/CSSCore';
 import {onCSSTransitionEnd} from './utils';
 import Button from './Button';
+import config from './config';
 
 export default class ToastrConfirm extends Component {
   static displayName = 'ToastrConfirm';
 
   static propTypes = {
-    confirm: PropTypes.object.isRequired,
-    confirmOptions: PropTypes.object
+    confirm: PropTypes.object.isRequired
   };
 
   constructor(props) {
     super(props);
+    let {options} = props.confirm;
+
+    this.okText = options.okText || config.confirm.okText;
+    this.cancelText = options.cancelText || config.confirm.cancelText;
+    this.transitionIn = options.transitionIn || config.confirm.transitionIn;
+    this.transitionOut = options.transitionOut || config.confirm.transitionOut;
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
     this.isHiding = false;
 
     if (this.props.confirm.show) {
@@ -58,20 +64,18 @@ export default class ToastrConfirm extends Component {
     if (add) {
       this.isHiding = false;
       CSSCore.addClass(body, 'toastr-confirm-active');
-      CSSCore.addClass(this.confirm, 'bounceInDown');
+      CSSCore.addClass(this.confirm, this.transitionIn);
       return;
     }
 
     this.isHiding = true;
-    CSSCore.addClass(this.confirm, 'bounceOutUp');
+    CSSCore.addClass(this.confirm, this.transitionOut);
   };
 
   _removeConfirm = () => {
     this.isHiding = false;
     this.props.hideConfirm();
     const body = document.querySelector('body');
-    CSSCore.removeClass(this.confirm, 'bounceOutUp');
-    CSSCore.removeClass(this.confirm, 'bounceInDown');
     CSSCore.removeClass(body, 'toastr-confirm-active');
   };
 
@@ -82,10 +86,10 @@ export default class ToastrConfirm extends Component {
           <div className="confirm animated" ref={ref => this.confirm = ref}>
             <div className="message">{this.props.confirm.message}</div>
             <Button onClick={this.handleConfirmClick.bind(this)}>
-              {this.props.confirmOptions.okText}
+              {this.okText}
             </Button>
             <Button onClick={this.handleCancelClick.bind(this)}>
-              {this.props.confirmOptions.cancelText}
+              {this.cancelText}
             </Button>
           </div>
         <div className="shadow"></div>

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,18 @@
-const config = {};
+const toastr = {};
+toastr.newestOnTop = true;
+toastr.timeOut = 5000;
+toastr.transitionIn = 'bounceIn';
+toastr.transitionOut = 'bounceOut';
 
-config.newestOnTop = true;
-config.timeOut = 5000;
-config.transitionIn = 'bounceIn';
-config.transitionOut = 'bounceOut';
+const confirm = {};
+confirm.transitionIn = 'bounceInDown';
+confirm.transitionOut = 'bounceOutUp';
+confirm.okText = 'ok';
+confirm.cancelText = 'cancel';
+
+const config = {
+  toastr,
+  confirm
+};
 
 export default config;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,8 +5,9 @@ import {ADD_TOASTR, REMOVE_TOASTR, CLEAN_TOASTR, SHOW_CONFIRM, HIDE_CONFIRM} fro
 const initialState = {
   toastrs: [],
   confirm: {
+    id: guid(),
     show: false,
-    options: null
+    options: {}
   }
 };
 
@@ -20,7 +21,7 @@ export default createReducer(initialState, {
       options: payload.options
     };
 
-    if (!config.newestOnTop) {
+    if (!config.toastr.newestOnTop) {
       return {
         ...state,
         toastrs: [
@@ -53,19 +54,17 @@ export default createReducer(initialState, {
     return {
       ...state,
       confirm: {
+        id: guid(),
         show: true,
         message: payload.message,
-        options: payload.options || null
+        options: payload.options || {}
       }
     };
   },
   [HIDE_CONFIRM]: (state) => {
     return {
       ...state,
-      confirm: {
-        show: false,
-        options: null
-      }
+      confirm: {...initialState.confirm}
     };
   }
 });

--- a/src/toastrEmitter.js
+++ b/src/toastrEmitter.js
@@ -18,7 +18,7 @@ export const toastrEmitter = {
   confirm: (...args) => {
     emitter.emit('toastr/confirm', {
       message: args[0].toString(),
-      options: args[1]
+      options: args[1] || {}
     });
   }
 };


### PR DESCRIPTION
As a suggestion to be able to configure confirm settings like toastrs settings:
- default settings are in config
- general options can be overriden by passing confirmOptions to ReduxToastr props
- options for particular confirm message can be passed in the options part of confirm call
