### PR TITLE
Adding icons prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 4.*
 lib
 dist/
+.idea

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Each of these methods can take up to three arguments the `title` a `message` and
 In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover` `removeOnClick`
 
 `icon` can be one of the following:
-- `'icon-close-round'`
-- `'icon-information-circle'`
-- `'icon-check-1'`
-- `'icon-exclamation-triangle'`
-- `'icon-exclamation-alert'`
+- `'toastr-icon-close-round'`
+- `'toastr-icon-information-circle'`
+- `'toastr-icon-check-1'`
+- `'toastr-icon-exclamation-triangle'`
+- `'toastr-icon-exclamation-alert'`
 
 
 ``` javascript

--- a/src/less/css-fonts.less
+++ b/src/less/css-fonts.less
@@ -13,43 +13,43 @@
 }
 
 [data-icon]:before {
-  font-family: "redux-toastr" !important;
+  font-family: "redux-toastr";
   content: attr(data-icon);
-  font-style: normal !important;
-  font-weight: normal !important;
-  font-variant: normal !important;
-  text-transform: none !important;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
   speak: none;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-[class^="icon-"]:before,
-[class*=" icon-"]:before {
-  font-family: "redux-toastr" !important;
-  font-style: normal !important;
-  font-weight: normal !important;
-  font-variant: normal !important;
-  text-transform: none !important;
+[class^="toastr-icon-"]:before,
+[class*=" toastr-icon-"]:before {
+  font-family: "redux-toastr";
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
   speak: none;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-close-round:before {
+.toastr-icon-close-round:before {
   content: "\62";
 }
-.icon-information-circle:before {
+.toastr-icon-information-circle:before {
   content: "\63";
 }
-.icon-check-1:before {
+.toastr-icon-check-1:before {
   content: "\64";
 }
-.icon-exclamation-triangle:before {
+.toastr-icon-exclamation-triangle:before {
   content: "\65";
 }
-.icon-exclamation-alert:before {
+.toastr-icon-exclamation-alert:before {
   content: "\69";
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,13 +62,13 @@ export function mapToToastrMessage(type, array) {
 export function mapToIcon(type) {
   switch (type) {
     case 'info':
-      return 'icon-information-circle';
+      return 'toastr-icon-information-circle';
     case 'success':
-      return 'icon-check-1';
+      return 'toastr-icon-check-1';
     case 'warning':
-      return 'icon-exclamation-triangle';
+      return 'toastr-icon-exclamation-triangle';
     case 'error':
-      return 'icon-exclamation-alert';
+      return 'toastr-icon-exclamation-alert';
     default:
       return type;
   }


### PR DESCRIPTION
Prefixing toastr icons so it doesn't enforce `redux-toastr` font to the whole app, breaking other general purpose icon packages like icomoon.

See https://github.com/diegoddox/react-redux-toastr/issues/46
