### PR TITLE
Fixed toastr method options not supporting overriding of transitionIn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ constructor(props) {
 # Toastr methods
 ##### Toastr: `success` `info` `warning` `light` and `error`
 Each of these methods can take up to three arguments the `title` a `message` and `options`.
-In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover`, `showCloseButton` and `progressBar`
+In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover`, `showCloseButton`, `progressBar`, `transitionIn` and `transitionOut`.
 
 ``` javascript
 import {toastr} from 'react-redux-toastr'

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -19,7 +19,7 @@ export default class ToastrBox extends Component {
     let {
       transitionIn,
       transitionOut
-    } = props.item;
+    } = props.item.options;
 
     this.isHiding = false;
     this.shouldClose = false;


### PR DESCRIPTION
…/Out.

The code to override the transitionIn/Out value was in place but not working due to this bug. 

However note that there is redundant code: [this override line](https://github.com/diegoddox/react-redux-toastr/blob/master/src/ToastrBox.js#L28) will now always take the second value because there is a previous merge with the first value [here](https://github.com/diegoddox/react-redux-toastr/blob/master/src/ReduxToastr.js#L71). That code however would be relevant if the props that ToastrBox received were different than those of ReduxTastr.