### PR TITLE
Add ability to disable cancel on confirm toastr

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ const toastrConfirmOptions = {
 toastr.confirm('Are you sure about that!', toastrConfirmOptions);
 ```
 
-You can make it so ok is the only option by:
+You can make it so 'ok' is the only button by:
 
 - Passing the `disableCancel` prop to the `toasterConfirmOptions` object:
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ const toastrConfirmOptions = {
 toastr.confirm('Are you sure about that!', toastrConfirmOptions);
 ```
 
-You can make it so 'ok' is the only button by:
+You can make it so `ok` is the only button by:
 
 - Passing the `disableCancel` prop to the `toasterConfirmOptions` object:
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ const toastrConfirmOptions = {
 toastr.confirm('Are you sure about that!', toastrConfirmOptions);
 ```
 
+You can make it so ok is the only option by:
+
+- Passing the `disableCancel` prop to the `toasterConfirmOptions` object:
+
+```javascript
+const toastrConfirmOptions = {
+  ...
+  disableCancel: true;
+};
+
+toastr.confirm('Are you sure about that!', toastrConfirmOptions);
+```
+
 ### Avatar: in case you wanna use the same avatar as the example
 [Avatar](https://github.com/diegoddox/react-redux-toastr/blob/master/development/Avatar.js)
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ const toastrConfirmOptions = {
   disableCancel: true;
 };
 
-toastr.confirm('Are you sure about that!', toastrConfirmOptions);
+toastr.confirm('You have timed out! Please log back in.', toastrConfirmOptions);
 ```
 
 ### Avatar: in case you wanna use the same avatar as the example

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Button = props => (
-  <button type="button" onClick={() => props.onClick()}>
+  <button type="button" onClick={() => props.onClick()} className={props.className}>
     <p>{props.children}</p>
   </button>
 );

--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -36,7 +36,8 @@ class ReduxToastr extends Component {
       transitionIn: 'bounceInDown',
       transitionOut: 'bounceOutUp',
       okText: 'ok',
-      cancelText: 'cancel'
+      cancelText: 'cancel',
+      hideCancel: true
     }
   };
 

--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -37,7 +37,7 @@ class ReduxToastr extends Component {
       transitionOut: 'bounceOutUp',
       okText: 'ok',
       cancelText: 'cancel',
-      disableCancel: true
+      disableCancel: false
     }
   };
 

--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -37,7 +37,7 @@ class ReduxToastr extends Component {
       transitionOut: 'bounceOutUp',
       okText: 'ok',
       cancelText: 'cancel',
-      hideCancel: true
+      disableCancel: true
     }
   };
 

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -26,11 +26,7 @@ class ToastrConfirm extends Component {
     this.cancelText = cancelText || confirmOptions.cancelText;
     this.transitionIn = transitionIn || confirmOptions.transitionIn;
     this.transitionOut = transitionOut || confirmOptions.transitionOut;
-    if (!disableCancel && disableCancel !== false) {
-      this.disableCancel = confirmOptions.disableCancel;
-    } else {
-      this.disableCancel = disableCancel;
-    }
+    this.disableCancel = (disableCancel != null) ? disableCancel : confirmOptions.disableCancel;
     _bind('setTransition removeConfirm handleOnKeyUp handleOnKeyDown', this);
     this.isKeyDown = false;
   }

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -18,14 +18,15 @@ class ToastrConfirm extends Component {
       okText,
       cancelText,
       transitionIn,
-      transitionOut
+      transitionOut,
+      hideCancel
     } = confirm.options;
 
     this.okText = okText || confirmOptions.okText;
     this.cancelText = cancelText || confirmOptions.cancelText;
     this.transitionIn = transitionIn || confirmOptions.transitionIn;
     this.transitionOut = transitionOut || confirmOptions.transitionOut;
-
+    this.hideCancel = hideCancel || confirmOptions.hideCancel;
     _bind('setTransition removeConfirm handleOnKeyUp handleOnKeyDown', this);
     this.isKeyDown = false;
   }
@@ -112,9 +113,9 @@ class ToastrConfirm extends Component {
 
   handleOnKeyUp(e) {
     const code = keyCode(e);
-    if (code == ESC) {
+    if (code == ESC && !this.hideCancel) {
       this.handleCancelClick();
-    } else if (code == ENTER && this.isKeyDown) {
+    } else if ((code == ENTER && this.isKeyDown) || this.hideCancel) {
       this.isKeyDown = false;
       this.handleConfirmClick();
     }
@@ -125,12 +126,17 @@ class ToastrConfirm extends Component {
       <div className="confirm-holder">
           <div className="confirm animated" ref={ref => this.confirm = ref}>
             <div className="message">{this.props.confirm.message}</div>
-            <Button onClick={this.handleConfirmClick.bind(this)}>
-              {this.okText}
-            </Button>
-            <Button onClick={this.handleCancelClick.bind(this)}>
-              {this.cancelText}
-            </Button>
+                <button className={this.hideCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
+                  {this.okText}
+                </button>
+
+            {
+              this.hideCancel ? null : (
+                <Button onClick={this.handleCancelClick.bind(this)}>
+                  {this.cancelText}
+                </Button>
+              )
+            }
           </div>
         <div className="shadow"></div>
       </div>

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -115,7 +115,9 @@ class ToastrConfirm extends Component {
     const code = keyCode(e);
     if (code == ESC && !this.disableCancel) {
       this.handleCancelClick();
-    } else if ((code == ENTER && this.isKeyDown) || this.disableCancel) {
+    } else if (code == ESC && this.disableCancel) {
+      this.handleConfirmClick();
+    } else if ((code == ENTER && this.isKeyDown)) {
       this.isKeyDown = false;
       this.handleConfirmClick();
     }

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -19,14 +19,14 @@ class ToastrConfirm extends Component {
       cancelText,
       transitionIn,
       transitionOut,
-      hideCancel
+      disableCancel
     } = confirm.options;
 
     this.okText = okText || confirmOptions.okText;
     this.cancelText = cancelText || confirmOptions.cancelText;
     this.transitionIn = transitionIn || confirmOptions.transitionIn;
     this.transitionOut = transitionOut || confirmOptions.transitionOut;
-    this.hideCancel = hideCancel || confirmOptions.hideCancel;
+    this.disableCancel = disableCancel || confirmOptions.disableCancel;
     _bind('setTransition removeConfirm handleOnKeyUp handleOnKeyDown', this);
     this.isKeyDown = false;
   }
@@ -113,9 +113,9 @@ class ToastrConfirm extends Component {
 
   handleOnKeyUp(e) {
     const code = keyCode(e);
-    if (code == ESC && !this.hideCancel) {
+    if (code == ESC && !this.disableCancel) {
       this.handleCancelClick();
-    } else if ((code == ENTER && this.isKeyDown) || this.hideCancel) {
+    } else if ((code == ENTER && this.isKeyDown) || this.disableCancel) {
       this.isKeyDown = false;
       this.handleConfirmClick();
     }
@@ -126,14 +126,14 @@ class ToastrConfirm extends Component {
       <div className="confirm-holder">
           <div className="confirm animated" ref={ref => this.confirm = ref}>
             <div className="message">{this.props.confirm.message}</div>
-                <button className={this.hideCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
+                <button className={this.disableCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
                   {this.okText}
                 </button>
 
             {
-              this.hideCancel ? null : (
+              this.disableCancel ? null : (
                 <Button onClick={this.handleCancelClick.bind(this)}>
-                  {this.cancelText}
+                  {this.disableCancel}
                 </Button>
               )
             }

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -131,13 +131,12 @@ class ToastrConfirm extends Component {
                 <button className={this.disableCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
                   {this.okText}
                 </button>
-
-            {
-              this.disableCancel ? null : (
-                <Button onClick={this.handleCancelClick.bind(this)}>
-                  {this.disableCancel}
-                </Button>
-              )
+                {
+                  this.disableCancel ? null : (
+                    <Button onClick={this.handleCancelClick.bind(this)}>
+                      {this.disableCancel}
+                    </Button>
+                )
             }
           </div>
         <div className="shadow"></div>

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -26,7 +26,11 @@ class ToastrConfirm extends Component {
     this.cancelText = cancelText || confirmOptions.cancelText;
     this.transitionIn = transitionIn || confirmOptions.transitionIn;
     this.transitionOut = transitionOut || confirmOptions.transitionOut;
-    this.disableCancel = disableCancel || confirmOptions.disableCancel;
+    if (!disableCancel && disableCancel !== false) {
+      this.disableCancel = confirmOptions.disableCancel;
+    } else {
+      this.disableCancel = disableCancel;
+    }
     _bind('setTransition removeConfirm handleOnKeyUp handleOnKeyDown', this);
     this.isKeyDown = false;
   }

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -128,13 +128,13 @@ class ToastrConfirm extends Component {
       <div className="confirm-holder">
           <div className="confirm animated" ref={ref => this.confirm = ref}>
             <div className="message">{this.props.confirm.message}</div>
-                <button className={this.disableCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
+                <Button className={this.disableCancel ? 'full-width' : ''} onClick={this.handleConfirmClick.bind(this)}>
                   {this.okText}
-                </button>
+                </Button>
                 {
                   this.disableCancel ? null : (
                     <Button onClick={this.handleCancelClick.bind(this)}>
-                      {this.disableCancel}
+                      {this.cancelText}
                     </Button>
                 )
             }

--- a/src/styles/confirm.scss
+++ b/src/styles/confirm.scss
@@ -74,6 +74,10 @@
         transform: scale(0);
       }
 
+      &.full-width {
+        width: 100%;
+      }
+
       // In order to avoid event bubbling put the transition on the active class
       &.active {
         &:before {


### PR DESCRIPTION
I need this functionality in order to notify a user when they have timed out that they need to log back in. This requires a single button confirm for the user to click to say they have seen the message and understand why it appeared.

In this scenario, being able to cancel does not make sense and should not be allowed as the user cannot avoid logging back in. 

The reason a regular toastr could not be used in this scenario is because the user needs to acknowledge the prompt before they are redirected to the log in screen.
