### PR TITLE
Export unwrapped ReduxToastr

### DIFF
--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -8,7 +8,7 @@ import {EE} from './toastrEmitter';
 import config from './config';
 import {updateConfig, _bind} from './utils';
 
-class ReduxToastr extends Component {
+export class ReduxToastr extends Component {
   static displayName = 'ReduxToastr';
 
   static propTypes = {


### PR DESCRIPTION
This PR helps the ReduxToastr component become more testable. It also allows a consumer to hook it up to a store property with a name other than `toastr`.