### PR TITLE
Add aria-live and role to toastr container

### DIFF
--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -94,7 +94,11 @@ class ReduxToastr extends Component {
 
   render() {
     return (
-      <div className={cn('redux-toastr', this.props.position, this.props.className)}>
+      <div
+        className={cn('redux-toastr', this.props.position, this.props.className)}
+        aria-live="assertive"
+        role="alert"
+      >
         {this.props.toastr.confirm &&
           <ToastrConfirm
             key={this.props.toastr.confirm.id}


### PR DESCRIPTION
This makes it so that toasts are announced to screen readers.
It's a good first step in making the component more accessible.

Other things that could be addressed in the future are:


- Using role="alertdialog" when there are interactive elements in the toast
- Confirm box doesn't trap keyboard focus and is not read to screen readers