### PR TITLE
Fix confirm dialog close when global confirm options provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 lib
 dist/
 .idea
+/yarn.lock

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ You can change the `ok` and `cancel` text by:
 - Passing the `confirm` props to the `ReduxToastr` component
 
 ```javascript
+<!-- please define both keys as this will override default okText & cancelText -->
 const options = {
   okText: 'confirm text',
   cancelText: 'cancel text'

--- a/development/store.js
+++ b/development/store.js
@@ -9,7 +9,6 @@ export default function configStore(initialState) {
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
   );
 
-
   if (module.hot) {
     module.hot.accept('./reducer', () => {
       const nextRootReducers = require('./reducer');

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "babel-plugin-transform-class-properties": "^6.2.2",
     "babel-plugin-transform-es2015-arrow-functions": "^6.1.18",
     "babel-plugin-transform-es2015-block-scoping": "^6.1.18",
+    "babel-plugin-transform-es2015-classes": "^6.1.18",
     "babel-plugin-transform-proto-to-assign": "^6.6.5",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",

--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -34,11 +34,8 @@ export class ReduxToastr extends React.Component {
     transitionOut: 'bounceOut',
     preventDuplicates: false,
     confirmOptions: {
-      transitionIn: 'bounceInDown',
-      transitionOut: 'bounceOutUp',
       okText: 'ok',
-      cancelText: 'cancel',
-      disableCancel: false
+      cancelText: 'cancel'
     }
   };
 

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -25,9 +25,9 @@ class ToastrConfirm extends React.Component {
 
     this.okText = okText || confirmOptions.okText;
     this.cancelText = cancelText || confirmOptions.cancelText;
-    this.transitionIn = transitionIn || confirmOptions.transitionIn;
-    this.transitionOut = transitionOut || confirmOptions.transitionOut;
-    this.disableCancel = (disableCancel != null) ? disableCancel : confirmOptions.disableCancel;
+    this.transitionIn = transitionIn || confirmOptions.transitionIn || props.transitionIn;
+    this.transitionOut = transitionOut || confirmOptions.transitionOut || props.transitionOut;
+    this.disableCancel = disableCancel || confirmOptions.disableCancel;
     _bind('setTransition removeConfirm handleOnKeyUp handleOnKeyDown', this);
     this.isKeyDown = false;
   }


### PR DESCRIPTION
In case when a global confirm options are provided without `transitionIn` or `transitionOut` confirm dialog will not closed anymore.

Ps. I've added a missed package and fix dev environment when a person doesn't use REDUX_DEVTOOLS_EXTENSION