### PR TITLE
Automatically close toastr box on timeout if animation is failed

### DIFF
--- a/development/Menu.js
+++ b/development/Menu.js
@@ -49,7 +49,7 @@ export default class Menu extends React.Component {
               position: 'bottom-right',
               timeOut: 10000,
               transitionIn: 'bounceInDown',
-              transitionOut: 'bounceOutUp'
+              transitionOut: 'bounceOutU'
             });
           }}>
             <span className="icon-info-circle"/>

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import ProgressBar from './ProgressBar';
 import Icon from './Icon';
-import {TRANSITIONS} from './constants';
 
 import {onCSSTransitionEnd, _bind} from './utils';
 
@@ -13,8 +12,8 @@ export default class ToastrBox extends React.Component {
   static propTypes = {
     item: PropTypes.shape({
       options: PropTypes.shape({
-        transitionIn: PropTypes.oneOf(TRANSITIONS.in),
-        transitionOut: PropTypes.oneOf(TRANSITIONS.out)
+        transitionIn: PropTypes.string,
+        transitionOut: PropTypes.string
       })
     })
   };

--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {onCSSTransitionEnd, _bind, keyCode, isBrowser} from './utils';
 import Button from './Button';
-import {TRANSITIONS} from './constants';
 
 const ENTER = 13;
 const ESC = 27;
@@ -11,9 +10,12 @@ const ESC = 27;
 export default class ToastrConfirm extends React.Component {
   static displayName = 'ToastrConfirm';
   static propTypes = {
-    confirm: PropTypes.object.isRequired,
-    transitionIn: PropTypes.oneOf(TRANSITIONS.in),
-    transitionOut: PropTypes.oneOf(TRANSITIONS.out)
+    confirm: PropTypes.shape({
+      options: PropTypes.shape({
+        transitionIn: PropTypes.string,
+        transitionOut: PropTypes.string
+      })
+    })
   };
 
   constructor(props) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 let toastr = {
+  maxAnimationDelay: 2000,
   newestOnTop: true,
   position: 'top-right',
   preventDuplicates: true

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,27 @@
 import ReactTransitionEvents from 'react/lib/ReactTransitionEvents';
 import config from './config';
 
-export function createReducer(initialState, fnMap) {
-  return (state = initialState, {type, payload}) => {
-    const handle = fnMap[type];
-    return handle ? handle(state, payload) : state;
-  };
-}
-
 function isString(obj) {
   if (typeof obj == 'string') {
     return true;
   }
   return false;
+}
+
+var toastrWarn;
+if (process.env.NODE_ENV === 'production') {
+  toastrWarn = () => {};
+} else {
+  toastrWarn = (message) => {
+    console.warn(`[react-redux-toastr] ${message}`);
+  };
+}
+
+export function createReducer(initialState, fnMap) {
+  return (state = initialState, {type, payload}) => {
+    const handle = fnMap[type];
+    return handle ? handle(state, payload) : state;
+  };
 }
 
 export function isBrowser() {
@@ -70,7 +79,15 @@ export function guid() {
 }
 
 export function onCSSTransitionEnd(node, callback) {
+  // if css animation is failed - dispatch event manually
+  const timeoutId = setTimeout(function() {
+    var e = new Event('transitionend');
+    toastrWarn('The toastr box was closed automatically, please check \'transitionOut\' prop value');
+    node.dispatchEvent(e);
+  }, config.maxAnimationDelay);
+
   const runOnce = (e) => {
+    clearTimeout(timeoutId);
     // stopPropagation is not working in IE11 and Edge, the transitionend from the Button.js is waiting
     // on the confirm animation to end first and not the Button.js
     e.stopPropagation();


### PR DESCRIPTION
I've made the second implementation - based on timeout, so a user is free to used own transitions. Please look at it(info toastr in the demo app) as I'm starting to like it more than the current