### PR TITLE
Add feature to provide ability to overide global preventDuplicate configuration

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -83,6 +83,8 @@ export function onCSSTransitionEnd(node, callback) {
 export function preventDuplication(currentData, newObjec) {
   let hasDuplication = false;
   currentData.forEach((item) => {
+    // If the toastr options implicitly specify not to prevent duplicates then skip
+    if(item.options.preventDuplicates === false) return;
     // Because the toastr has a unic id we will check by the title and message.
     if (item.title === newObjec.title && item.message === newObjec.message && item.type === newObjec.type) {
       hasDuplication = true;


### PR DESCRIPTION
In the src/utils.js make a check inside the currentData loop if the item.options.preventDuplicates === false, if evaluates to true then skip. 

File: src/utils.js
Line number: 87