### PR TITLE
Added width option for toastr width

### DIFF
--- a/development/Menu.js
+++ b/development/Menu.js
@@ -34,7 +34,8 @@ export default class Menu extends React.Component {
               {
                 timeOut: 10000,
                 position: 'top-left',
-                progressBar: true
+                progressBar: true,
+                width:'300px'
               }
             );
           }}>

--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -110,11 +110,14 @@ export class ReduxToastr extends React.Component {
   }
 
   _renderToastrs() {
+    const {toastr} = this.props;
+    const width = toastr.toastrs && toastr.toastrs[0] && toastr.toastrs[0].options && toastr.toastrs[0].options.width;
+    const style = width ? {width:width} : {};
     return (
       <span>
         {this.toastrPositions.map(position => {
           return (
-            <div key={position} className={position}>
+            <div key={position} className={position} style={style}>
               {this._renderToastrForPosition(position)}
             </div>
           );


### PR DESCRIPTION
Related issue: #101 
I am using custom toastr component and printing multiple messages in same toastr. Those messages sometimes are long, which has bad appearance. I searched an option for it, but could not find one.  I found the issue mentioned on the top. So, I implemented it.