### PR TITLE
Fixed webkit font-smoothing bug on bounceIn animation

### DIFF
--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -44,29 +44,29 @@
 
   0% {
     opacity: 0;
-    transform: scale3d(.3, .3, .3);
+    transform: perspective(1px) scale3d(.3, .3, .3);
   }
 
   20% {
-    transform: scale3d(1.1, 1.1, 1.1);
+    transform: perspective(1px) scale3d(1.1, 1.1, 1.1);
   }
 
   40% {
-    transform: scale3d(.9, .9, .9);
+    transform: perspective(1px) scale3d(.9, .9, .9);
   }
 
   60% {
     opacity: 1;
-    transform: scale3d(1.03, 1.03, 1.03);
+    transform: perspective(1px) scale3d(1.03, 1.03, 1.03);
   }
 
   80% {
-    transform: scale3d(.97, .97, .97);
+    transform: perspective(1px) scale3d(.97, .97, .97);
   }
 
   to {
     opacity: 1;
-    transform: scale3d(1, 1, 1);
+    transform: perspective(1px) scale3d(1, 1, 1);
   }
 }
 


### PR DESCRIPTION
Let's try this again... I've added 'perspective(1px)' to the bounceIn animation to improve the issue in webkit where the font seems to jump during the animation.