### PR TITLE
Allow to specify removeOnHoverTimeout interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Toastr accepts the following methods: `success`  `info`  `warning`  `light`  `er
 
 ##### Toastr: `success`  `info`  `warning`  `light`  `error`  `remove` and `removeByType`
 Each of these methods can take up to three arguments the `title` a `message` and `options`.
-In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover`, `showCloseButton`, `onCloseButtonClick`, `progressBar`, `transitionIn`, `position`, `attention`, `onAttentionClick`  and `transitionOut`.
+In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover`,`removeOnHoverTimeOut`,`showCloseButton`, `onCloseButtonClick`, `progressBar`, `transitionIn`, `position`, `attention`, `onAttentionClick`  and `transitionOut`.
 
 ``` javascript
 import {toastr} from 'react-redux-toastr'
@@ -204,7 +204,8 @@ const toastrMessageOptions = {
   timeOut: 3000, // Default value is 0
   onShowComplete: () => console.log('SHOW: animation is done'),
   onHideComplete: () => console.log('HIDE: animation is done'),
-  removeOnHover: false // Default value is false
+  removeOnHover: false, // Default value is false
+  removeOnHoverTimeOut: 1000, // Default value is 1000
   component: React.Component
 };
 toastr.message('Title', toastrMessageOptions)

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -107,10 +107,10 @@ export default class ToastrBox extends React.Component {
   }
 
   mouseLeave() {
-    const {removeOnHover} = this.props.item.options;
+    const {removeOnHover,removeOnHoverTimeOut} = this.props.item.options;
 
     if (!this.isHiding && (removeOnHover || this.shouldClose)) {
-      const interval = removeOnHover === true ? 1000 : removeOnHover;
+        const interval = removeOnHover === true ? (removeOnHoverTimeOut || 1000) : removeOnHover;
       this._setIntervalId(setTimeout(this._removeToastr, interval));
 
       const {progressBar} = this.props.item.options;


### PR DESCRIPTION
There is a hard coded value that may be not suitable in some cases:

https://github.com/diegoddox/react-redux-toastr/blob/6aac56c1188165225547568b17dcbabcae7e907d/src/ToastrBox.js#L113

I have just added another property `removeOnHoverTimeOut` which will can be used to change the value.

The change is backward compatible, the default stays 1000.