### PR TITLE
Add support for React.Component title/message

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Toastr accepts the following methods: `success`  `info`  `warning`  `light`  `er
 
 ##### Toastr: `success`  `info`  `warning`  `light`  `error`  `remove` and `removeByType`
 Each of these methods can take up to three arguments the `title` a `message` and `options`.
+`title` and `message` can be strings or React Components.
 In `options` you can specify `timeOut` `icon` `onShowComplete` `onHideComplete` `className` `component` `removeOnHover`,`removeOnHoverTimeOut`,`showCloseButton`, `onCloseButtonClick`, `onToastrClick`, `progressBar`, `transitionIn`, `position`, `attention`, `onAttentionClick`, `transitionOut` and `closeOnToastrClick`.
 
 ``` javascript
@@ -270,9 +271,9 @@ You can add custom buttons by:
 
 - Passing the `buttons` prop to the `toasterConfirmOptions` object.
   The buttons are inserted after the OK and the cancel button.
-  
+
   Each button config can have a `text`, `handler` and a `className` property.
-  
+
   If you want to move the original OK or cancel button to a different place, just
   insert a button config with a boolean flag `ok` or `cancel` at the desired position
   (note that all other properties are ignored in this button config).

--- a/development/CustomComponent.js
+++ b/development/CustomComponent.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+// fake i18n formatting
+const formatMessage = x => x.split('').reverse().join('');
+
+export default class CustomComponent extends React.Component {
+  componentDidMount() {
+    console.log('CustomComponent is here.', this.props.text);
+  }
+
+  render() {
+    return (
+      <div>
+        { formatMessage(this.props.text) }
+      </div>
+    )
+  }
+}

--- a/development/Menu.js
+++ b/development/Menu.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {toastr} from './../src/';
 import loremIpsum from 'lorem-ipsum';
 import Avatar from './Avatar';
+import CustomComponent from './CustomComponent';
 import messageText from './messageText';
 
 export default class Menu extends React.Component {
@@ -89,6 +90,12 @@ export default class Menu extends React.Component {
           </li>
           <li className="message" onClick={() => toastr.confirm('The confirm message')}>
             <span className="icon-check-5"/>
+          </li>
+          <li className="message" onClick={() => toastr.success(
+            <CustomComponent text="Nice Title" />,
+            <CustomComponent text="Nice Message" />
+          )}>
+            <span className="icon-double-diamonds"/>
           </li>
       </ul>
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,10 @@ function isString(obj) {
   return false;
 }
 
+function isReactComponent(obj) {
+  return !!obj.type
+}
+
 export function toastrWarn(message) {
   if (process.env.NODE_ENV === 'production') {
     return null;
@@ -55,7 +59,9 @@ export function mapToToastrMessage(type, array) {
   obj.type = type;
   obj.position = config.position;
 
-  obj.options = array.filter(item => typeof item == 'object')[0] || {};
+  obj.options = array.find(item =>
+    typeof item == 'object' && !isReactComponent(item)
+  ) || {};
 
   if (obj.options.hasOwnProperty('position')) {
     obj.position = obj.options.position;
@@ -76,11 +82,16 @@ export function mapToToastrMessage(type, array) {
     obj.options.timeOut = 0;
   }
 
-  if (isString(array[0]) && isString(array[1])) {
+  if (array.length === 3) {
     obj.title = array[0];
     obj.message = array[1];
-  } else if (isString(array[0]) && !isString(array[1])) {
-    obj.title = array[0];
+  } else if (array.length === 2) {
+    if (isReactComponent(array[1]) || isString(array[1])) {
+      obj.title = array[0];
+      obj.message = array[1];
+    } else {
+      obj.message = array[0];
+    }
   } else {
     obj.message = array[0];
   }


### PR DESCRIPTION
This allows `title` and `message` to be React.Components.  It should play nicely with #203, but I'd appreciate any ideas on a _better_ test to see if an argument is/is not a React.Component (see `isReactComponent`).

Let me know if I missed tests or linting or anything.