### PR TITLE
bug fix - avoid of invoke undefined focus method. Problem occurs when…

### DIFF
--- a/src/ToastrConfirm.js
+++ b/src/ToastrConfirm.js
@@ -53,7 +53,7 @@ export default class ToastrConfirm extends React.Component {
       this.setTransition(true);
     }
     // when toast loads the toast close button automatically focuses on the toast control
-    if (this.closeButton !== undefined) {
+    if (this.closeButton !== undefined && this.closeButton.focus !== undefined) {
       this.closeButton.focus();
     }
   }


### PR DESCRIPTION
… close btn is custom component.
for example 


	deleteCardItem() {
		const toastrConfirmOptions = {
			onOk: () => this.props.deleteInvoiceCardItem(this.props.editableInvoiceItemCardsIndex),
			onCancel: () => {},
			okText: <TranslateCtn trKey="Ok" />,
			cancelText: <TranslateCtn trKey="Cancel" />,
			closeButton: true
		};
		toastr.confirm(<TranslateCtn trKey="AreYouSure?InvoiceCardItemWillBeDeleted" />, toastrConfirmOptions);
	}