### PR TITLE
Possibility to specify a11y ID

### DIFF
--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -34,7 +34,7 @@ export default class ToastrBox extends React.Component {
     this.transitionIn = transitionIn || this.props.transitionIn;
     this.transitionOut = transitionOut || this.props.transitionOut;
     // an identifier to facilitate aria labelling for a11y for multiple instances of the component family in the DOM
-    this.id = Math.floor(Math.random() * 9999);
+    this.id = props.item.a11yId || Math.floor(Math.random() * 9999);
 
     this.state = {progressBar: null};
 
@@ -218,6 +218,12 @@ export default class ToastrBox extends React.Component {
       title
     } = this.props.item;
 
+    const ariaAttributes = {};
+    if (title)
+      ariaAttributes['aria-labelledby'] = `dialogTitle-${this.id}`;
+    if (message)
+      ariaAttributes['aria-describedby'] = `dialogDesc-${this.id}`;
+
     return (
       <div>
         <div className="rrt-left-container">
@@ -226,7 +232,7 @@ export default class ToastrBox extends React.Component {
           </div>
         </div>
         {options.status && type === 'light' && <div className={classnames('toastr-status', options.status)}/>}
-        <div className="rrt-middle-container" role="alertdialog" aria-labelledby={`dialogTitle-${this.id}`} aria-describedby={`dialogDesc-${this.id}`}>
+        <div className="rrt-middle-container" role="alertdialog" {...ariaAttributes}>
           {title && <div id={`dialogTitle-${this.id}`} className="rrt-title">{title}</div>}
           {message && <div id={`dialogDesc-${this.id}`} className="rrt-text">{message}</div>}
           {options.component && this.renderSubComponent()}

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -219,10 +219,14 @@ export default class ToastrBox extends React.Component {
     } = this.props.item;
 
     const ariaAttributes = {};
-    if (title)
+
+    if (title) {
       ariaAttributes['aria-labelledby'] = `dialogTitle-${this.id}`;
-    if (message)
+    }
+
+    if (message) {
       ariaAttributes['aria-describedby'] = `dialogDesc-${this.id}`;
+    }
 
     return (
       <div>

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -30,6 +30,10 @@ export default createReducer(initialState, {
       ...toastr
     };
 
+    if (!newToastr.a11yId && toastr && toastr.hasOwnProperty('id') && !toastr.hasOwnProperty('a11yId')) {
+      newToastr.a11yId = toastr.id;
+    }
+
     let newState = {};
     if (!config.newestOnTop) {
       newState = {


### PR DESCRIPTION
Now it will be possible to define suffix used in ARIA attributes at development-time rather than using `Math.random` at run-time to prevent issue described in #239