### PR TITLE
feat(getState): add ability to find state at different locations

### DIFF
--- a/src/ReduxToastr.js
+++ b/src/ReduxToastr.js
@@ -155,8 +155,12 @@ export class ReduxToastr extends React.Component {
 }
 
 export default connect(
-  state => ({
-    toastr: state.toastr ? state.toastr : state.get('toastr')
+  (state, ownProps) => ({
+    toastr: state.toastr
+      ? state.toastr
+      : typeof ownProps.getState === 'function'
+        ? ownProps.getState(state)
+        : state.get('toastr')
   }),
   actions
 )(ReduxToastr);


### PR DESCRIPTION
Currently, this lib expects the state to be at the key `toastr` (and even handles when the state object is an immutable object (via `state.get`). There is no way to define a custom / different location easily.

This adds an optional prop to the `ReduxToastr` component which is a function that takes the current state to provide the toastr state.

The goal of this is to allow users to define custom toastr state location.

#128