### PR TITLE
Fix close button keypress handler

### DIFF
--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -105,7 +105,7 @@ export default class ToastrBox extends React.Component {
     }
   };
 
-  handlePressEnterOrSpaceKeyCloseButton(e) {
+  handlePressEnterOrSpaceKeyCloseButton = (e) => {
     if (e.key === ' ' || e.key === 'enter') {
       this.handleClickCloseButton(e);
     }


### PR DESCRIPTION
This PR fixes the `this` binding for the close button keypress handler. Currently it causes the following error to occur when you press space.
```
Uncaught TypeError: Cannot read property 'handleClickCloseButton' of undefined
```