### PR TITLE
Fix wrong key string comparison

### DIFF
--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -100,13 +100,13 @@ export default class ToastrBox extends React.Component {
   }
 
   handlePressEnterOrSpaceKeyToastr = (e) => {
-    if (e.key === ' ' || e.key === 'enter') {
+    if (e.key === ' ' || e.key === 'Enter') {
       this.handleClickToastr(e);
     }
   };
 
   handlePressEnterOrSpaceKeyCloseButton = (e) => {
-    if (e.key === ' ' || e.key === 'enter') {
+    if (e.key === ' ' || e.key === 'Enter') {
       this.handleClickCloseButton(e);
     }
   }


### PR DESCRIPTION
The string produced by pressing the enter key actually is `Enter` instead of `enter` so this fixes the toastr not being closed when pressing the enter key.

@diegoddox how do you feel about adding tests?