### PR TITLE
Move react-refresh plugin to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,8 @@
       "version": "7.6.11",
       "license": "MIT",
       "dependencies": {
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "classnames": "^2.2.3",
-        "eventemitter3": "^3.1.0",
-        "react-refresh": "^0.14.0"
+        "eventemitter3": "^3.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.2.3",
@@ -20,6 +18,7 @@
         "@babel/plugin-proposal-class-properties": "^7.2.3",
         "@babel/preset-env": "^7.2.3",
         "@babel/preset-react": "^7.0.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "autoprefixer": "^9.4.4",
         "babel-eslint": "^10.0.1",
         "babel-loader": "^8.0.5",
@@ -47,6 +46,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^7.2.6",
+        "react-refresh": "^0.14.0",
         "redux": "^4.1.2",
         "rimraf": "^2.4.4",
         "sass": "^1.43.4",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.22.15",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
     "autoprefixer": "^9.8.8",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.3.0",
@@ -101,6 +102,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^7.2.9",
+    "react-refresh": "^0.14.0",
     "redux": "^4.2.1",
     "rimraf": "^2.7.1",
     "sass": "^1.67.0",
@@ -118,10 +120,8 @@
     "redux": "^3.0.5 || ^4.0.0"
   },
   "dependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
     "classnames": "^2.3.2",
-    "eventemitter3": "^3.1.2",
-    "react-refresh": "^0.14.0"
+    "eventemitter3": "^3.1.2"
   },
   "homepage": "https://github.com/diegoddox/react-redux-toastr#readme"
 }


### PR DESCRIPTION
The `@pmmmwh/react-refresh-webpack-plugin` and `react-refresh` dependencies seem to only be used for the webpack dev server and are not required for downstream users of this library, so this PR moves them to the dev dependencies section of the `package.json` file. This change significantly reduces the dependency tree of downstream packages.